### PR TITLE
Update 16.7.md

### DIFF
--- a/docs/chap16/16.7.md
+++ b/docs/chap16/16.7.md
@@ -16,7 +16,7 @@ metadata:
   name: laptop
   namespace: study-ingress
 spec:
-ingressClassName: nginx
+  ingressClassName: nginx
   rules:
   - host: test.com
     http:


### PR DESCRIPTION
修复19行的格式错误，将 ingressClassName置于spec之下。